### PR TITLE
Remove ruby-debug dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    omniauth-ldap (1.0.0.beta1)
+    omniauth-ldap (1.0.1)
       net-ldap (~> 0.2.2)
-      omniauth (~> 1.0.0)
+      omniauth (~> 1.0)
       pyu-ruby-sasl (~> 0.0.3.1)
       rubyntlm (~> 0.1.1)
 
@@ -74,6 +74,6 @@ DEPENDENCIES
   omniauth-ldap!
   rack-test
   rb-fsevent
-  rspec (~> 2.6)
+  rspec (~> 2.7)
   ruby-debug19
   simplecov

--- a/lib/omniauth/strategies/ldap.rb
+++ b/lib/omniauth/strategies/ldap.rb
@@ -1,5 +1,4 @@
 require 'omniauth'
-require 'ruby-debug'
 
 module OmniAuth
   module Strategies


### PR DESCRIPTION
Remove the `ruby-debug` dependency from the LDAP strategy.

Bundler also updated `Gemfile.lock` but these changes aren't necessary; feel free to discard.
