### PR TITLE
Wrapping original LDAP info in a hash so it doesn't break omniauth auth_hash interface

### DIFF
--- a/lib/omniauth/strategies/ldap.rb
+++ b/lib/omniauth/strategies/ldap.rb
@@ -58,7 +58,7 @@ module OmniAuth
         @user_info
       }
       extra {
-        @ldap_user_info
+        { 'original_ldap_entry' => @ldap_user_info }
       }
             
       def self.map_user(mapper, object)


### PR DESCRIPTION
In omniauth-ldap/lib/omniauth/strategies/ldap.rb on line 60 extra information for auth_hash is provided.

In my case, and I would guess in general, it doesn't work since the @ldap_user_info is an instance of the Net::LDAP::Entry and doesn't fit in omniauth expectations from the return value.

I fixed it by simply wrapping it in a hash. Providing the pull request together with the issue.
