### PR TITLE
Net::LDAP::Entry always returns an array of values.  

### DIFF
--- a/lib/omniauth/strategies/ldap.rb
+++ b/lib/omniauth/strategies/ldap.rb
@@ -65,14 +65,14 @@ module OmniAuth
         mapper.each do |key, value|
           case value
             when String
-              user[key] = object[value.downcase.to_sym].to_s if object[value.downcase.to_sym]
+              user[key] = object[value.downcase.to_sym].first if object[value.downcase.to_sym]
             when Array
-              value.each {|v| (user[key] = object[v.downcase.to_sym].to_s; break;) if object[v.downcase.to_sym]}
+              value.each {|v| (user[key] = object[v.downcase.to_sym].first; break;) if object[v.downcase.to_sym]}
             when Hash
               value.map do |key1, value1|
                 pattern = key1.dup
                 value1.each_with_index do |v,i|
-                  part = ''; v.collect(&:downcase).collect(&:to_sym).each {|v1| (part = object[v1].to_s; break;) if object[v1]}
+                  part = ''; v.collect(&:downcase).collect(&:to_sym).each {|v1| (part = object[v1].first; break;) if object[v1]}
                   pattern.gsub!("%#{i}",part||'')
                 end
                 user[key] = pattern

--- a/spec/omniauth/strategies/ldap_spec.rb
+++ b/spec/omniauth/strategies/ldap_spec.rb
@@ -75,10 +75,10 @@ describe "OmniAuth::Strategies::LDAP" do
     context 'success' do
       let(:auth_hash){ last_request.env['omniauth.auth'] }
       before(:each) do
-        @adaptor.stub(:bind_as).and_return({:dn => 'cn=ping, dc=intridea, dc=com', :mail => 'ping@intridea.com', :givenname => 'Ping', :sn => 'Yu', 
-                                            :telephonenumber => '555-555-5555', :mobile => '444-444-4444', :uid => 'ping', :title => 'dev', :address => 'k street',
-                                            :l => 'Washington', :st => 'DC', :co => "U.S.A", :postofficebox => '20001', :wwwhomepage => 'www.intridea.com',
-                                            :jpegphoto => 'http://www.intridea.com/ping.jpg', :description => 'omniauth-ldap'})
+        @adaptor.stub(:bind_as).and_return({:dn => ['cn=ping, dc=intridea, dc=com'], :mail => ['ping@intridea.com'], :givenname => ['Ping'], :sn => ['Yu'], 
+                                            :telephonenumber => ['555-555-5555'], :mobile => ['444-444-4444'], :uid => ['ping'], :title => ['dev'], :address =>[ 'k street'],
+                                            :l => ['Washington'], :st => ['DC'], :co => ["U.S.A"], :postofficebox => ['20001'], :wwwhomepage => ['www.intridea.com'],
+                                            :jpegphoto => ['http://www.intridea.com/ping.jpg'], :description => ['omniauth-ldap']})
         post('/auth/ldap/callback', {:username => 'ping', :password => 'password'})
       end
       


### PR DESCRIPTION
Net::LDAP::Entry (http://net-ldap.rubyforge.org/Net/LDAP/Entry.html) explicitly
returns an array of values for each attribute. The result of OmniAuth::Strategies::LDAP#map_user
was returning a string representation of the attribute values array (ie. '[\"attribute_value\"]'),
and it should be returning the actual attribute value (ie "attribute_value").
