### PR TITLE
use current user info as LDAP credential

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Allowed values of :method are: :plain, :ssl, :tls.
   Use them to initialize a SASL connection to server. If you are not familiar with these authentication methods, 
   please just avoid them.
 
+:use_user_credential Allow you to use current login user's info as LDAP credential. true/false.
+  If you don't have a default credential (:bind_dn and :password) for ldap config, 
+  You can fake it by using the current login user's name and password.
+
 Direct users to '/auth/ldap' to have them authenticated via your company's LDAP server.
 
 

--- a/lib/omniauth/strategies/ldap.rb
+++ b/lib/omniauth/strategies/ldap.rb
@@ -39,6 +39,13 @@ module OmniAuth
         @adaptor = OmniAuth::LDAP::Adaptor.new @options
 
         raise MissingCredentialsError.new("Missing login credentials") if request['username'].nil? || request['password'].nil?
+        
+        if @adaptor.use_user_credential
+          @adaptor.bind_dn = request['username'] + '@' + @adaptor.base_to_host(@adaptor.base)
+          @adaptor.password = request['password']
+          @adaptor.reset_connection
+        end
+
         begin
           @ldap_user_info = @adaptor.bind_as(:filter => Net::LDAP::Filter.eq(@adaptor.uid, @options[:name_proc].call(request['username'])),:size => 1, :password => request['password'])
           return fail!(:invalid_credentials) if !@ldap_user_info

--- a/spec/omniauth-ldap/adaptor_spec.rb
+++ b/spec/omniauth-ldap/adaptor_spec.rb
@@ -49,6 +49,14 @@ describe "OmniAuth::LDAP::Adaptor" do
       adaptor.connection.instance_variable_get('@auth')[:initial_credential].should =~ /^NTLMSSP/      
       adaptor.connection.instance_variable_get('@auth')[:challenge_response].should_not be_nil      
     end
+    it 'should reset connection' do
+      adaptor = OmniAuth::LDAP::Adaptor.new({host: "192.168.1.145", method: 'plain', base: 'dc=intridea, dc=com', port: 389, uid: 'sAMAccountName'})
+      adaptor.connection.instance_variable_get('@auth').should == {:method => :anonymous, :username => nil, :password => nil}
+      adaptor.bind_dn ='someone'
+      adaptor.password='secret'
+      adaptor.reset_connection
+      adaptor.connection.instance_variable_get('@auth').should == {:method => :simple, :username => 'someone', :password => 'secret'}
+    end
   end
   
   describe 'bind_as' do


### PR DESCRIPTION
if :bind_dn and :password is not set. this patch fake it by using current login user's info as credential. 

In my company (fortune 500), IT dept only creates new LDAP account for real person. So I can't set default credential, this patch resolves such issue.
