### PR TITLE
fix LDAP blank password error

### DIFF
--- a/lib/omniauth/strategies/ldap.rb
+++ b/lib/omniauth/strategies/ldap.rb
@@ -38,7 +38,7 @@ module OmniAuth
       def callback_phase
         @adaptor = OmniAuth::LDAP::Adaptor.new @options
 
-        raise MissingCredentialsError.new("Missing login credentials") if request['username'].nil? || request['password'].nil?
+        raise MissingCredentialsError.new("Missing login credentials") if request['username'].nil? || request['password'].nil? || request['password'].empty? 
         begin
           @ldap_user_info = @adaptor.bind_as(:filter => Net::LDAP::Filter.eq(@adaptor.uid, @options[:name_proc].call(request['username'])),:size => 1, :password => request['password'])
           return fail!(:invalid_credentials) if !@ldap_user_info


### PR DESCRIPTION
Related to pull request #294.

When LDAP is being used with a bind_dn and a password provided in the configuration; a user can simply enter a valid username and leave the password field blank and still log in. This patch corrects that behavior and throws and AuthenticationError when the user does not provide a password.
