### PR TITLE
changing callback_path to callback_url to account for relative root url

### DIFF
--- a/lib/omniauth/strategies/ldap.rb
+++ b/lib/omniauth/strategies/ldap.rb
@@ -28,7 +28,7 @@ module OmniAuth
 
       def request_phase
         OmniAuth::LDAP::Adaptor.validate @options
-        f = OmniAuth::Form.new(:title => (options[:title] || "LDAP Authentication"), :url => callback_path)
+        f = OmniAuth::Form.new(:title => (options[:title] || "LDAP Authentication"), :url => callback_url)
         f.text_field 'Login', 'username'
         f.password_field 'Password', 'password'
         f.button "Sign In"

--- a/spec/omniauth/strategies/ldap_spec.rb
+++ b/spec/omniauth/strategies/ldap_spec.rb
@@ -35,7 +35,7 @@ describe "OmniAuth::Strategies::LDAP" do
     end
 
     it 'should have the callback as the action for the form' do
-      last_response.body.should be_include("action='/auth/ldap/callback'")
+      last_response.body.should be_include("action='http://example.org/auth/ldap/callback'")
     end
 
     it 'should have a text field for each of the fields' do


### PR DESCRIPTION
When an app is deployed to a subdirectory of the webroot, so that the root url is like http://host/subdirectory, the authentication callback fails, since callback_path is passed as the action to the form, which causes the user to be directed to http://host/auth/ldap/callback. 

This fix passes callback_url as the action to the form so that the form action is the full url: http://host/subdirectory/auth/ldap/callback for applications deployed to a subdirectory, or http://host/auth/ldap/callback for applications deployed in the host's webroot.
