### PR TITLE
don't allow empty password to authenticate

### DIFF
--- a/lib/omniauth/strategies/ldap.rb
+++ b/lib/omniauth/strategies/ldap.rb
@@ -38,7 +38,7 @@ module OmniAuth
       def callback_phase
         @adaptor = OmniAuth::LDAP::Adaptor.new @options
 
-        raise MissingCredentialsError.new("Missing login credentials") if request['username'].nil? || request['password'].nil?
+        raise MissingCredentialsError.new("Missing login credentials") if request['username'].nil? || request['password'].nil? || request['password'].empty?
         begin
           @ldap_user_info = @adaptor.bind_as(:filter => Net::LDAP::Filter.eq(@adaptor.uid, @options[:name_proc].call(request['username'])),:size => 1, :password => request['password'])
           return fail!(:invalid_credentials) if !@ldap_user_info

--- a/spec/omniauth/strategies/ldap_spec.rb
+++ b/spec/omniauth/strategies/ldap_spec.rb
@@ -59,6 +59,12 @@ describe "OmniAuth::Strategies::LDAP" do
       it 'should raise MissingCredentialsError' do
         lambda{post('/auth/ldap/callback', {})}.should raise_error OmniAuth::Strategies::LDAP::MissingCredentialsError
       end
+      it 'should raise MissingCredentialsError for nil password' do
+        lambda{post('/auth/ldap/callback', {:username => 'ping'})}.should raise_error OmniAuth::Strategies::LDAP::MissingCredentialsError
+      end
+      it 'should raise MissingCredentialsError for empty password' do
+        lambda{post('/auth/ldap/callback', {:username => 'ping', :password => ''})}.should raise_error OmniAuth::Strategies::LDAP::MissingCredentialsError
+      end
       it 'should redirect to error page' do        
         post('/auth/ldap/callback', {:username => 'ping', :password => 'password'})
         last_response.should be_redirect


### PR DESCRIPTION
Leaving the password blank would allow any user to login with any username. Added a check for empty password. Includes working spec.
