### PR TITLE
add license information to the gemspec

### DIFF
--- a/omniauth-ldap.gemspec
+++ b/omniauth-ldap.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |gem|
   gem.description   = %q{A LDAP strategy for OmniAuth.}
   gem.summary       = %q{A LDAP strategy for OmniAuth.}
   gem.homepage      = "https://github.com/intridea/omniauth-ldap"
+  gem.license       = "MIT"
 
   gem.add_runtime_dependency     'omniauth', '~> 1.0'
   gem.add_runtime_dependency     'net-ldap', '~> 0.2.2'


### PR DESCRIPTION
This way it can be used with rubygems.org API
