### PR TITLE
Report the reason for bind failure

### DIFF
--- a/lib/omniauth/strategies/ldap.rb
+++ b/lib/omniauth/strategies/ldap.rb
@@ -40,7 +40,7 @@ module OmniAuth
         return fail!(:missing_credentials) if missing_credentials?
         begin
           @ldap_user_info = @adaptor.bind_as(:filter => Net::LDAP::Filter.eq(@adaptor.uid, @options[:name_proc].call(request['username'])),:size => 1, :password => request['password'])
-          return fail!(:invalid_credentials) if !@ldap_user_info
+          return fail!(@adaptor.bind_failure_reason) if !@ldap_user_info
 
           @user_info = self.class.map_user(@@config, @ldap_user_info)
           super


### PR DESCRIPTION
When an account's credentials are correct, but they still cannot
bind it is usually due to a locked account.

This shouldn't give any extra info to an attacker (they must
already know the username and password) but it does help
users who get locked out (too many incorrect passwords, for example)
to know what's wrong.
