### PR TITLE
Update net-ldap gem to avoid errors with some LDAP Servers

### DIFF
--- a/omniauth-ldap.gemspec
+++ b/omniauth-ldap.gemspec
@@ -9,15 +9,15 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/intridea/omniauth-ldap"
 
   gem.add_runtime_dependency     'omniauth', '~> 1.0'
-  gem.add_runtime_dependency     'net-ldap', '~> 0.2.2'
+  gem.add_runtime_dependency     'net-ldap', '~> 0.3.1'
   gem.add_runtime_dependency     'pyu-ruby-sasl', '~> 0.0.3.1'
-  gem.add_runtime_dependency     'rubyntlm', '~> 0.1.1'  
+  gem.add_runtime_dependency     'rubyntlm', '~> 0.1.1'
   gem.add_development_dependency 'rspec', '~> 2.7'
   gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'rack-test'
   gem.add_development_dependency 'libnotify'
   gem.add_development_dependency 'ruby-debug19'
-  
+
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.files         = `git ls-files`.split("\n")
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
I've tried to use omniauth-ldap with a 389-ds/IPA LDAP Server that uses protocol v3. LDAP searching was not working, returning with a Protocol Error. I found this thread which explains a very similar problem: http://comments.gmane.org/gmane.comp.version-control.gitlab/406

I found that only by updating the net-ldap gem this issue gets fixed, so I'm providing PR with the gem version updated.

I'm not adding the updated Gemfile.lock since that should not be in the repo.

The specs ran successfully!
