### PR TITLE
Add ability to run through a list of hosts when binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,59 @@
 # OmniAuth LDAP
 
-== LDAP
+### LDAP
 
 Use the LDAP strategy as a middleware in your application:
 
-    use OmniAuth::Strategies::LDAP, 
-        :title => "My LDAP", 
-        :host => '10.101.10.1',
-        :port => 389,
-        :method => :plain,
-        :base => 'dc=intridea, dc=com',
-        :uid => 'sAMAccountName',
-        :name_proc => Proc.new {|name| name.gsub(/@.*$/,'')}
-        :bind_dn => 'default_bind_dn'
-        :password => 'password'
+``` ruby
+use OmniAuth::Strategies::LDAP, 
+    :title => "My LDAP", 
+    :host => '10.101.10.1',
+    :port => 389,
+    :method => :plain,
+    :base => 'dc=intridea, dc=com',
+    :uid => 'sAMAccountName',
+    :name_proc => Proc.new {|name| name.gsub(/@.*$/,'')}
+    :bind_dn => 'default_bind_dn'
+    :password => 'password'
+```
 
-All of the listed options are required, with the exception of :title, :name_proc, :bind_dn, and :password.
-Allowed values of :method are: :plain, :ssl, :tls.
+All of the listed options are required, with the exception of `:title`, `:name_proc`, `:bind_dn`, and `:password`.
 
-:bind_dn and :password is the default credentials to perform user lookup.
-  most LDAP servers require that you supply a complete DN as a binding-credential, along with an authenticator
-  such as a password. But for many applications, you often don’t have a full DN to identify the user. 
-  You usually get a simple identifier like a username or an email address, along with a password. 
-  Since many LDAP servers don't allow anonymous access, search function will require a bound connection, 
-  :bind_dn and :password will be required for searching on the username or email to retrieve the DN attribute 
-  for the user. If the LDAP server allows anonymous access, you don't need to provide these two parameters.
+Allowed values of `:method` are: `:plain`, `:ssl`, `:tls`.
 
-:uid is the LDAP attribute name for the user name in the login form. 
-  typically AD would be 'sAMAccountName' or 'UserPrincipalName', while OpenLDAP is 'uid'.
+`:bind_dn` and `:password` are the default credentials to perform user lookup.
 
-:name_proc allows you to match the user name entered with the format of the :uid attributes. 
-  For example, value of 'sAMAccountName' in AD contains only the windows user name. If your user prefers using 
-  email to login, a name_proc as above will trim the email string down to just the windows login name. 
-  In summary, use :name_proc to fill the gap between the submitted username and LDAP uid attribute value.
+Most LDAP servers require that you supply a complete DN as a binding-credential, along with an authenticator such as a password. But for many applications, you often don’t have a full DN to identify the user. You usually get a simple identifier like a username or an email address, along with a password. 
+
+Since many LDAP servers don't allow anonymous access, search function will require a bound connection, `:bind_dn` and `:password` will be required for searching on the username or email to retrieve the DN attribute for the user. 
+
+If the LDAP server allows anonymous access, you don't need to provide these two parameters.
+
+`:uid` is the LDAP attribute name for the user name in the login form. Typically AD would be `sAMAccountName` or `UserPrincipalName`, while OpenLDAP is `uid`.
+
+`:name_proc` allows you to match the user name entered with the format of the `:uid` attributes. For example, value of `sAMAccountName` in AD contains only the windows user name. 
+
+If your user prefers using email to login, a `:name_proc` as above will trim the email string down to just the windows login name. 
+
+In summary, use `:name_proc` to fill the gap between the submitted username and LDAP uid attribute value.
  
-:try_sasl and :sasl_mechanisms are optional. :try_sasl [true | false], :sasl_mechanisms ['DIGEST-MD5' | 'GSS-SPNEGO']
-  Use them to initialize a SASL connection to server. If you are not familiar with these authentication methods, 
-  please just avoid them.
+`:try_sasl` and `:sasl_mechanisms` are optional. 
 
-Direct users to '/auth/ldap' to have them authenticated via your company's LDAP server.
+```
+:try_sasl [true | false]
+:sasl_mechanisms ['DIGEST-MD5' | 'GSS-SPNEGO']
+```
+
+Use them to initialize a SASL connection to server. If you are not familiar with these authentication methods, please just avoid them.
+
+Direct users to `/auth/ldap` to have them authenticated via your company's LDAP server.
 
 
 ## License
 
 Copyright (C) 2011 by Ping Yu and Intridea, Inc.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
@@ -59,6 +62,4 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/lib/omniauth-ldap/adaptor.rb
+++ b/lib/omniauth-ldap/adaptor.rb
@@ -25,7 +25,7 @@ module OmniAuth
       }
 
       attr_accessor :bind_dn, :password
-      attr_reader :connection, :uid, :base, :auth
+      attr_reader :connections, :uid, :base, :auth
       def self.validate(configuration={})
         message = []
         MUST_HAVE_KEYS.each do |name|
@@ -48,39 +48,50 @@ module OmniAuth
           :encryption => method,
           :base => @base
         }
-        @uri = construct_uri(@host, @port, @method != :plain)
-        
+
+        @host = [ @host ] unless @host.is_a?(Array)
+        @uri = @host.map {|h| construct_uri(h, @port, @method != :plain)}
+
         @bind_method = @try_sasl ? :sasl : (@allow_anonymous||!@bind_dn||!@password ? :anonymous : :simple)
-        
-        
+
         @auth = sasl_auths({:username => @bind_dn, :password => @password}).first if @bind_method == :sasl
         @auth ||= { :method => @bind_method,
                     :username => @bind_dn,
                     :password => @password
                   }
         config[:auth] = @auth
-        @connection = Net::LDAP.new(config)
+
+        @connections = @host.map {|host| Net::LDAP.new(config.merge(:host => host))}
       end
-      
+
       #:base => "dc=yourcompany, dc=com",
       # :filter => "(mail=#{user})",
       # :password => psw
-      def bind_as(args = {})        
+      def bind_as(args = {})
         result = false
-        @connection.open do |me|
-          rs = me.search args
-          if rs and rs.first and dn = rs.first.dn
-            password = args[:password]
-            method = args[:method] || @method
-            password = password.call if password.respond_to?(:call)
-            if method == 'sasl'
-            result = rs.first if me.bind(sasl_auths({:username => dn, :password => password}).first)
-            else
-            result = rs.first if me.bind(:method => :simple, :username => dn,
-                                :password => password)
+        @connections.find do |connection|
+          begin
+            connection.open do |me|
+              rs = me.search(args)
+              if rs and rs.first and dn = rs.first.dn
+                password = args[:password]
+                method = args[:method] || @method
+                password = password.call if password.respond_to?(:call)
+                if method == 'sasl'
+                result = rs.first if me.bind(sasl_auths({:username => dn, :password => password}).first)
+                else
+                result = rs.first if me.bind(:method => :simple, :username => dn,
+                                    :password => password)
+                end
+              end
             end
+          rescue Net::LDAP::LdapError => e
+            # FIXME(auxesis): this isn't the best, but @logger often doesn't exist
+            puts e.message
           end
+          result
         end
+
         result
       end
 

--- a/spec/omniauth-ldap/adaptor_spec.rb
+++ b/spec/omniauth-ldap/adaptor_spec.rb
@@ -13,44 +13,55 @@ describe "OmniAuth::LDAP::Adaptor" do
 
     it 'should setup ldap connection with anonymous' do
       adaptor = OmniAuth::LDAP::Adaptor.new({host: "192.168.1.145", method: 'plain', base: 'dc=intridea, dc=com', port: 389, uid: 'sAMAccountName'})
-      adaptor.connection.should_not == nil
-      adaptor.connection.host.should == '192.168.1.145'
-      adaptor.connection.port.should == 389
-      adaptor.connection.base.should == 'dc=intridea, dc=com'
-      adaptor.connection.instance_variable_get('@auth').should == {:method => :anonymous, :username => nil, :password => nil}
+      adaptor.connections.first.should_not == nil
+      adaptor.connections.first.host.should == '192.168.1.145'
+      adaptor.connections.first.port.should == 389
+      adaptor.connections.first.base.should == 'dc=intridea, dc=com'
+      adaptor.connections.first.instance_variable_get('@auth').should == {:method => :anonymous, :username => nil, :password => nil}
     end
 
     it 'should setup ldap connection with simple' do
       adaptor = OmniAuth::LDAP::Adaptor.new({host: "192.168.1.145", method: 'plain', base: 'dc=intridea, dc=com', port: 389, uid: 'sAMAccountName', bind_dn: 'bind_dn', password: 'password'})
-      adaptor.connection.should_not == nil
-      adaptor.connection.host.should == '192.168.1.145'
-      adaptor.connection.port.should == 389
-      adaptor.connection.base.should == 'dc=intridea, dc=com'
-      adaptor.connection.instance_variable_get('@auth').should == {:method => :simple, :username => 'bind_dn', :password => 'password'}
+      adaptor.connections.first.should_not == nil
+      adaptor.connections.first.host.should == '192.168.1.145'
+      adaptor.connections.first.port.should == 389
+      adaptor.connections.first.base.should == 'dc=intridea, dc=com'
+      adaptor.connections.first.instance_variable_get('@auth').should == {:method => :simple, :username => 'bind_dn', :password => 'password'}
     end
 
     it 'should setup ldap connection with sasl-md5' do
       adaptor = OmniAuth::LDAP::Adaptor.new({host: "192.168.1.145", method: 'plain', base: 'dc=intridea, dc=com', port: 389, uid: 'sAMAccountName', try_sasl: true, sasl_mechanisms: ["DIGEST-MD5"], bind_dn: 'bind_dn', password: 'password'})
-      adaptor.connection.should_not == nil
-      adaptor.connection.host.should == '192.168.1.145'
-      adaptor.connection.port.should == 389
-      adaptor.connection.base.should == 'dc=intridea, dc=com'
-      adaptor.connection.instance_variable_get('@auth')[:method].should == :sasl
-      adaptor.connection.instance_variable_get('@auth')[:mechanism].should == 'DIGEST-MD5'
-      adaptor.connection.instance_variable_get('@auth')[:initial_credential].should == ''
-      adaptor.connection.instance_variable_get('@auth')[:challenge_response].should_not be_nil
+      adaptor.connections.first.should_not == nil
+      adaptor.connections.first.host.should == '192.168.1.145'
+      adaptor.connections.first.port.should == 389
+      adaptor.connections.first.base.should == 'dc=intridea, dc=com'
+      adaptor.connections.first.instance_variable_get('@auth')[:method].should == :sasl
+      adaptor.connections.first.instance_variable_get('@auth')[:mechanism].should == 'DIGEST-MD5'
+      adaptor.connections.first.instance_variable_get('@auth')[:initial_credential].should == ''
+      adaptor.connections.first.instance_variable_get('@auth')[:challenge_response].should_not be_nil
     end
 
     it 'should setup ldap connection with sasl-gss' do
       adaptor = OmniAuth::LDAP::Adaptor.new({host: "192.168.1.145", method: 'plain', base: 'dc=intridea, dc=com', port: 389, uid: 'sAMAccountName', try_sasl: true, sasl_mechanisms: ["GSS-SPNEGO"], bind_dn: 'bind_dn', password: 'password'})
-      adaptor.connection.should_not == nil
-      adaptor.connection.host.should == '192.168.1.145'
-      adaptor.connection.port.should == 389
-      adaptor.connection.base.should == 'dc=intridea, dc=com'
-      adaptor.connection.instance_variable_get('@auth')[:method].should == :sasl
-      adaptor.connection.instance_variable_get('@auth')[:mechanism].should == 'GSS-SPNEGO'
-      adaptor.connection.instance_variable_get('@auth')[:initial_credential].should =~ /^NTLMSSP/
-      adaptor.connection.instance_variable_get('@auth')[:challenge_response].should_not be_nil
+      adaptor.connections.first.should_not == nil
+      adaptor.connections.first.host.should == '192.168.1.145'
+      adaptor.connections.first.port.should == 389
+      adaptor.connections.first.base.should == 'dc=intridea, dc=com'
+      adaptor.connections.first.instance_variable_get('@auth')[:method].should == :sasl
+      adaptor.connections.first.instance_variable_get('@auth')[:mechanism].should == 'GSS-SPNEGO'
+      adaptor.connections.first.instance_variable_get('@auth')[:initial_credential].should =~ /^NTLMSSP/
+      adaptor.connections.first.instance_variable_get('@auth')[:challenge_response].should_not be_nil
+    end
+
+    it 'should authenticate against multiple hosts' do
+      adaptor = OmniAuth::LDAP::Adaptor.new({host: ["192.168.1.145", "192.168.2.150"], method: 'plain', base: 'dc=intridea, dc=com', port: 389, uid: 'sAMAccountName', bind_dn: 'bind_dn', password: 'password'})
+      adaptor.connections.size.should == 2
+      adaptor.connections.each do |connection|
+        connection.should_not == nil
+        %w(192.168.1.145 192.168.2.150).should be_include(connection.host)
+        connection.port.should == 389
+        connection.base.should == 'dc=intridea, dc=com'
+      end
     end
   end
 
@@ -60,17 +71,30 @@ describe "OmniAuth::LDAP::Adaptor" do
 
     it 'should bind simple' do
       adaptor = OmniAuth::LDAP::Adaptor.new({host: "192.168.1.126", method: 'plain', base: 'dc=score, dc=local', port: 389, uid: 'sAMAccountName', bind_dn: 'bind_dn', password: 'password'})
-      adaptor.connection.should_receive(:open).and_yield(adaptor.connection)
-      adaptor.connection.should_receive(:search).with(args).and_return([rs])
-      adaptor.connection.should_receive(:bind).with({:username => 'new dn', :password => args[:password], :method => :simple}).and_return(true)
+      adaptor.connections.each_with_index {|c,i| c.should_receive(:open).and_yield(adaptor.connections[i]) }
+      adaptor.connections.each {|c| c.should_receive(:search).with(args).and_return([rs]) }
+      adaptor.connections.each {|c| c.should_receive(:bind).with({:username => 'new dn', :password => args[:password], :method => :simple}).and_return(true) }
       adaptor.bind_as(args).should == rs
     end
 
     it 'should bind sasl' do
       adaptor = OmniAuth::LDAP::Adaptor.new({host: "192.168.1.145", method: 'plain', base: 'dc=intridea, dc=com', port: 389, uid: 'sAMAccountName', try_sasl: true, sasl_mechanisms: ["GSS-SPNEGO"], bind_dn: 'bind_dn', password: 'password'})
-      adaptor.connection.should_receive(:open).and_yield(adaptor.connection)
-      adaptor.connection.should_receive(:search).with(args).and_return([rs])
-      adaptor.connection.should_receive(:bind).and_return(true)
+      adaptor.connections.each_with_index {|c,i| c.should_receive(:open).and_yield(adaptor.connections[i]) }
+      adaptor.connections.each {|c| c.should_receive(:search).with(args).and_return([rs]) }
+      adaptor.connections.each {|c| c.should_receive(:bind).and_return(true) }
+      adaptor.bind_as(args).should == rs
+    end
+
+    it 'should bind for each host' do
+      adaptor = OmniAuth::LDAP::Adaptor.new({host: ["192.168.1.145", "192.168.2.150"], method: 'plain', base: 'dc=score, dc=local', port: 389, uid: 'sAMAccountName', bind_dn: 'bind_dn', password: 'password'})
+      adaptor.connections.first.should_receive(:open).and_yield(adaptor.connections.first)
+      adaptor.connections.first.should_receive(:search).with(args).and_return([rs])
+      adaptor.connections.first.should_receive(:bind).and_return(true)
+
+      adaptor.connections[1..-1].each_with_index {|c,i| c.should_not_receive(:open) }
+      adaptor.connections[1..-1].each {|c| c.should_not_receive(:search).with(args) }
+      adaptor.connections[1..-1].each {|c| c.should_not_receive(:bind) }
+
       adaptor.bind_as(args).should == rs
     end
   end


### PR DESCRIPTION
If `:host` is provided an Array, OmniAuth LDAP will iterate through and attempt to bind each server. 

It also catches exceptions from Net::LDAP and moves onto the next LDAP server. 
