### PR TITLE
Add patch from https://github.com/syndicut/omniauth-ldap/commit/b524feb6...

### DIFF
--- a/lib/omniauth/strategies/ldap.rb
+++ b/lib/omniauth/strategies/ldap.rb
@@ -64,14 +64,14 @@ module OmniAuth
         mapper.each do |key, value|
           case value
           when String
-            user[key] = object[value.downcase.to_sym].first if object[value.downcase.to_sym]
+            user[key] = object[value.downcase.to_sym].first if object.respond_to? value.downcase.to_sym
           when Array
-            value.each {|v| (user[key] = object[v.downcase.to_sym].first; break;) if object[v.downcase.to_sym]}
+            value.each {|v| (user[key] = object[v.downcase.to_sym].first; break;) if object.respond_to? v.downcase.to_sym}
           when Hash
             value.map do |key1, value1|
               pattern = key1.dup
               value1.each_with_index do |v,i|
-                part = ''; v.collect(&:downcase).collect(&:to_sym).each {|v1| (part = object[v1].first; break;) if object[v1]}
+                part = ''; v.collect(&:downcase).collect(&:to_sym).each {|v1| (part = object[v1].first; break;) if object.respond_to? v1}
                 pattern.gsub!("%#{i}",part||'')
               end
               user[key] = pattern


### PR DESCRIPTION
...3048591a20de0f70c2d597f0b9d6a156 to fix problem with LDAP authentication in GitLab.

If the respective keys are not present in LDAP, the code fails and does not continue with the next alternative configured key; in turn, LDAP authentication in GitLab fails as no uid or email is found.

In my opinion, this is a general bug that should be fixed.
