### PR TITLE
Update version of RubyNTLM gem

### DIFF
--- a/omniauth-ldap.gemspec
+++ b/omniauth-ldap.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency     'omniauth', '~> 1.0'
   gem.add_runtime_dependency     'net-ldap', '~> 0.3.1'
   gem.add_runtime_dependency     'pyu-ruby-sasl', '~> 0.0.3.1'
-  gem.add_runtime_dependency     'rubyntlm', '~> 0.1.1'
+  gem.add_runtime_dependency     'rubyntlm', '~> 0.3'
   gem.add_development_dependency 'rspec', '~> 2.7'
   gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'rack-test'


### PR DESCRIPTION
RubyNTLM is back under development.

Savon (soap interface gem) is using a newer version of rubyntlm, causing a problem for applications which need both ldap and soap.

Any reason omniauth-ldap needs the old rubyntlm from 2006?
