### PR TITLE
Add options to retrieve LDAP group membership

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Use the LDAP strategy as a middleware in your application:
         :name_proc => Proc.new {|name| name.gsub(/@.*$/,'')}
         :bind_dn => 'default_bind_dn'
         :password => 'password'
+        :group_query => '(&(objectClass=posixGroup)(memberUid=%{username}))'
+        :group_attribute => 'cn'
 
 All of the listed options are required, with the exception of :title, :name_proc, :bind_dn, and :password.
 Allowed values of :method are: :plain, :ssl, :tls.
@@ -44,6 +46,15 @@ Allowed values of :method are: :plain, :ssl, :tls.
 :try_sasl and :sasl_mechanisms are optional. :try_sasl [true | false], :sasl_mechanisms ['DIGEST-MD5' | 'GSS-SPNEGO']
   Use them to initialize a SASL connection to server. If you are not familiar with these authentication methods, 
   please just avoid them.
+
+:group_query will perform an additional search on the LDAP server after a user has successfully 
+  authenticated, and add information about their group membership to the auth object returned by 
+  Omniauth under the extra/groups key. %{username} will be replaced with the value of the field specified 
+  by uid. %{dn} will be replaced by the dn of the authenticated user. If using this option, you must 
+  also specify group_attribute. Set group_query to nil or false to disable this additional query.
+ 
+:group_attribute is the LDAP attribute to extract from the entries returned by group_query. This 
+  will be added to the auth object returned by Omniauth under the extra/groups key.
 
 Direct users to '/auth/ldap' to have them authenticated via your company's LDAP server.
 

--- a/lib/omniauth-ldap/adaptor.rb
+++ b/lib/omniauth-ldap/adaptor.rb
@@ -86,6 +86,10 @@ module OmniAuth
         result
       end
 
+      def search args = {}
+        @connection.search args
+      end
+
       private
       def ensure_method(method)
           method ||= "plain"

--- a/lib/omniauth-ldap/adaptor.rb
+++ b/lib/omniauth-ldap/adaptor.rb
@@ -3,7 +3,6 @@
 require 'rack'
 require 'net/ldap'
 require 'net/ntlm'
-require 'uri'
 require 'sasl'
 require 'kconv'
 module OmniAuth
@@ -48,11 +47,9 @@ module OmniAuth
           :encryption => method,
           :base => @base
         }
-        @uri = construct_uri(@host, @port, @method != :plain)
-        
         @bind_method = @try_sasl ? :sasl : (@allow_anonymous||!@bind_dn||!@password ? :anonymous : :simple)
-        
-        
+
+
         @auth = sasl_auths({:username => @bind_dn, :password => @password}).first if @bind_method == :sasl
         @auth ||= { :method => @bind_method,
                     :username => @bind_dn,
@@ -61,11 +58,11 @@ module OmniAuth
         config[:auth] = @auth
         @connection = Net::LDAP.new(config)
       end
-      
+
       #:base => "dc=yourcompany, dc=com",
       # :filter => "(mail=#{user})",
       # :password => psw
-      def bind_as(args = {})        
+      def bind_as(args = {})
         result = false
         @connection.open do |me|
           rs = me.search args
@@ -140,10 +137,6 @@ module OmniAuth
         [Net::NTLM::Message::Type1.new.serialize, nego]
       end
 
-      def construct_uri(host, port, ssl)
-        protocol = ssl ? "ldaps" : "ldap"
-        URI.parse("#{protocol}://#{host}:#{port}").to_s
-      end
     end
   end
 end

--- a/lib/omniauth-ldap/adaptor.rb
+++ b/lib/omniauth-ldap/adaptor.rb
@@ -13,7 +13,21 @@ module OmniAuth
       class AuthenticationError < StandardError; end
       class ConnectionError < StandardError; end
 
-      VALID_ADAPTER_CONFIGURATION_KEYS = [:host, :port, :method, :bind_dn, :password, :try_sasl, :sasl_mechanisms, :uid, :base, :allow_anonymous, :filter]
+      VALID_ADAPTER_CONFIGURATION_KEYS = [
+        :host, 
+        :port, 
+        :method, 
+        :bind_dn, 
+        :password, 
+        :try_sasl, 
+        :sasl_mechanisms, 
+        :uid, 
+        :base, 
+        :allow_anonymous, 
+        :filter, 
+        :group_query, 
+        :group_attribute
+      ]
 
       # A list of needed keys. Possible alternatives are specified using sub-lists.
       MUST_HAVE_KEYS = [:host, :port, :method, [:uid, :filter], :base]
@@ -25,7 +39,7 @@ module OmniAuth
       }
 
       attr_accessor :bind_dn, :password
-      attr_reader :connection, :uid, :base, :auth, :filter
+      attr_reader :connection, :uid, :base, :auth, :filter, :group_query
       def self.validate(configuration={})
         message = []
         MUST_HAVE_KEYS.each do |names|

--- a/lib/omniauth-ldap/version.rb
+++ b/lib/omniauth-ldap/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module LDAP
-    VERSION = "1.0.3"
+    VERSION = "1.0.4"
   end
 end

--- a/lib/omniauth/strategies/ldap.rb
+++ b/lib/omniauth/strategies/ldap.rb
@@ -59,7 +59,7 @@ module OmniAuth
 
         uid = ldap_user_info[@options[:uid].intern].first
         dn = ldap_user_info[:dn].first
-        groups = adaptor.search(filter: adaptor.group_query % {username: uid, dn: dn})
+        groups = adaptor.search(filter: adaptor.group_query % {username: Net::LDAP::Filter.escape(uid), dn: Net::LDAP::Filter.escape(dn)})
         groups.collect!{|g|g[options[:group_attribute].intern].first}
         return groups
       end


### PR DESCRIPTION
This change allows the user to configure an additional query that will retrieve the users LDAP group membership and populate it under the "extra" key in the returned auth hash. This is implemented in a way that is very similar to how the filter option was recently implemented. Tests and updated README included.
