### PR TITLE
Depend on net-ldap 0.x > 0.3

### DIFF
--- a/omniauth-ldap.gemspec
+++ b/omniauth-ldap.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.license       = "MIT"
 
   gem.add_runtime_dependency     'omniauth', '~> 1.0'
-  gem.add_runtime_dependency     'net-ldap', '~> 0.3.1'
+  gem.add_runtime_dependency     'net-ldap', '~> 0.3'
   gem.add_runtime_dependency     'pyu-ruby-sasl', '~> 0.0.3.1'
   gem.add_runtime_dependency     'rubyntlm', '~> 0.1.1'
   gem.add_development_dependency 'rspec', '~> 2.7'


### PR DESCRIPTION
I think it's safe to depend on `~> 0.3` to also allow `0.4` and `0.5` etc.
