### PR TITLE
Make LDAP bind failure cause an ldap_error, rather than an invalid_credentials

### DIFF
--- a/lib/omniauth-ldap/adaptor.rb
+++ b/lib/omniauth-ldap/adaptor.rb
@@ -71,7 +71,9 @@ module OmniAuth
         result = false
         @connection.open do |me|
           rs = me.search args
-          if rs and rs.first and dn = rs.first.dn
+          raise ConnectionError.new("bind failed") unless rs
+
+          if rs.first and dn = rs.first.dn
             password = args[:password]
             method = args[:method] || @method
             password = password.call if password.respond_to?(:call)

--- a/spec/omniauth-ldap/adaptor_spec.rb
+++ b/spec/omniauth-ldap/adaptor_spec.rb
@@ -73,5 +73,14 @@ describe "OmniAuth::LDAP::Adaptor" do
       adaptor.connection.should_receive(:bind).and_return(true)
       adaptor.bind_as(args).should == rs
     end
+
+    it "should raise a ConnectionError if the bind fails" do
+      adaptor = OmniAuth::LDAP::Adaptor.new({host: "192.168.1.126", method: 'plain', base: 'dc=score, dc=local', port: 389, uid: 'sAMAccountName', bind_dn: 'bind_dn', password: 'password'})
+      adaptor.connection.should_receive(:open).and_yield(adaptor.connection)
+      # Net::LDAP#search returns nil if the operation was not successful
+      adaptor.connection.should_receive(:search).with(args).and_return(nil)
+      adaptor.connection.should_receive(:bind).never
+      lambda { adaptor.bind_as(args) }.should raise_error OmniAuth::LDAP::Adaptor::ConnectionError
+    end
   end
 end


### PR DESCRIPTION
Fixes #51
