### PR TITLE
Updates use of rubyntlm for version >~ 0.6.1 (Fixes: #70)

### DIFF
--- a/lib/omniauth-ldap/adaptor.rb
+++ b/lib/omniauth-ldap/adaptor.rb
@@ -135,7 +135,7 @@ module OmniAuth
         nego = proc {|challenge|
           t2_msg = Net::NTLM::Message.parse( challenge )
           bind_dn, domain = bind_dn.split('\\').reverse
-          t2_msg.target_name = Net::NTLM::encode_utf16le(domain) if domain
+          t2_msg.target_name = Net::NTLM::EncodeUtil.encode_utf16le(domain) if domain
           t3_msg = t2_msg.response( {:user => bind_dn, :password => psw}, {:ntlmv2 => true} )
           t3_msg.serialize
         }

--- a/omniauth-ldap.gemspec
+++ b/omniauth-ldap.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency     'omniauth', '~> 1.0'
   gem.add_runtime_dependency     'net-ldap', '~> 0.12'
   gem.add_runtime_dependency     'pyu-ruby-sasl', '~> 0.0.3.2'#0.0.3.1 has been yanked
-  gem.add_runtime_dependency     'rubyntlm', '~> 0.3.4'
+  gem.add_runtime_dependency     'rubyntlm', '~> 0.6.1'
   gem.add_development_dependency 'rspec', '~> 2.7'
   gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'rack-test'


### PR DESCRIPTION
- Updates the gemspec to depend on rubyntlm >~ 0.6.1
- Fixes OmniAuth module to use the new EncodeUtil class in rubyntlm for
  encoding as UTF-16 LE.
