### PR TITLE
allow bind against the current user

### DIFF
--- a/lib/omniauth/strategies/ldap.rb
+++ b/lib/omniauth/strategies/ldap.rb
@@ -35,6 +35,8 @@ module OmniAuth
       end
 
       def callback_phase
+        @options[:password] = @options[:password].sub('%{password}', request['password']) unless request['password'].nil?
+        @options[:bind_dn] = @options[:bind_dn].sub('%{username}', request['username']) unless request['username'].nil?
         @adaptor = OmniAuth::LDAP::Adaptor.new @options
 
         return fail!(:missing_credentials) if missing_credentials?


### PR DESCRIPTION
added to be able to use %{password} and %{username} in the LDAP omniauth initializer
credits @pscdodd https://github.com/omniauth/omniauth-ldap/issues/59#issuecomment-372246080