### PR TITLE
Support OmniAuth 2.0.0

### DIFF
--- a/lib/omniauth-ldap/adaptor.rb
+++ b/lib/omniauth-ldap/adaptor.rb
@@ -60,8 +60,8 @@ module OmniAuth
                     :password => @password
                   }
         config[:auth] = @auth
+        config[:encryption] = method
         @connection = Net::LDAP.new(config)
-        @connection.encryption(method)
       end
 
       #:base => "dc=yourcompany, dc=com",

--- a/omniauth-ldap.gemspec
+++ b/omniauth-ldap.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency     'pyu-ruby-sasl', '~> 0.0.3.3'
   gem.add_runtime_dependency     'rubyntlm', '~> 0.6.2'
   gem.add_development_dependency 'rspec', '~> 3.0'
-  gem.add_development_dependency 'simplecov'
-  gem.add_development_dependency 'rack-test'
+  gem.add_development_dependency 'simplecov', '~> 0.11'
+  gem.add_development_dependency 'rack-test', '~> 0.6', '>= 0.6.3'
 
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.files         = `git ls-files`.split("\n")

--- a/omniauth-ldap.gemspec
+++ b/omniauth-ldap.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/intridea/omniauth-ldap"
   gem.license       = "MIT"
 
-  gem.add_runtime_dependency     'omniauth', '~> 1.8.1'
+  gem.add_runtime_dependency     'omniauth', '~> 2.0.0'
   gem.add_runtime_dependency     'net-ldap', '~> 0.16'
   gem.add_runtime_dependency     'pyu-ruby-sasl', '~> 0.0.3.3'
   gem.add_runtime_dependency     'rubyntlm', '~> 0.6.2'

--- a/spec/omniauth/strategies/ldap_spec.rb
+++ b/spec/omniauth/strategies/ldap_spec.rb
@@ -27,8 +27,17 @@ describe "OmniAuth::Strategies::LDAP" do
     expect(OmniAuth::Utils.camelize('ldap')).to eq 'LDAP'
   end
 
-  describe '/auth/ldap' do
+  describe 'get /auth/ldap' do
     before(:each){ get '/auth/ldap' }
+
+    it 'should return 404' do
+      expect(last_response.status).to eq 404
+      expect(last_response.body).to_not include("<form")
+    end
+  end
+
+  describe '/auth/ldap' do
+    before(:each){ post('/auth/ldap', {}) }
 
     it 'should display a form' do
       expect(last_response.status).to eq 200

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,8 @@ require 'rack/test'
 require 'omniauth'
 require 'omniauth-ldap'
 
+OmniAuth.config.request_validation_phase = proc {}
+
 RSpec.configure do |config|
   config.include Rack::Test::Methods
   config.extend  OmniAuth::Test::StrategyMacros, :type => :strategy

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,8 @@ require 'rack/test'
 require 'omniauth'
 require 'omniauth-ldap'
 
+TEST_LOGGER = Logger.new(StringIO.new)
+OmniAuth.config.logger = TEST_LOGGER
 OmniAuth.config.request_validation_phase = proc {}
 
 RSpec.configure do |config|


### PR DESCRIPTION
Bumps the OmniAuth dependency to 2.0.0 and tweaks the specs to use POST in the request phase.